### PR TITLE
Updates to how the msquic flags are added to the cmake build

### DIFF
--- a/msquic/msvc/evercrypt/CMakeLists.txt
+++ b/msquic/msvc/evercrypt/CMakeLists.txt
@@ -45,8 +45,10 @@ enable_language(ASM_MASM)
 
 include_directories(../include)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${QUIC_C_FLAGS} -D__STDC_FORMAT_MACROS /FI../include/CommonInclude.h")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__STDC_FORMAT_MACROS /FI../include/CommonInclude.h")
 
 add_library(evercrypt STATIC ${SOURCES})
+
+target_compile_options(evercrypt PRIVATE ${QUIC_C_FLAGS})
 
 add_dependencies(evercrypt kremlib)

--- a/msquic/msvc/kremlib/CMakeLists.txt
+++ b/msquic/msvc/kremlib/CMakeLists.txt
@@ -29,6 +29,8 @@ set(SOURCES
 
 include_directories(../include)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${QUIC_C_FLAGS} -D__STDC_FORMAT_MACROS /FI../include/CommonInclude.h")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__STDC_FORMAT_MACROS /FI../include/CommonInclude.h")
 
 add_library(kremlib STATIC ${SOURCES})
+
+target_compile_options(kremlib PRIVATE ${QUIC_C_FLAGS})

--- a/msquic/msvc/mitls/CMakeLists.txt
+++ b/msquic/msvc/mitls/CMakeLists.txt
@@ -45,8 +45,10 @@ set(SOURCES
 
 include_directories(../include)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${QUIC_C_FLAGS} -D__STDC_FORMAT_MACROS /FI../include/CommonInclude.h")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__STDC_FORMAT_MACROS /FI../include/CommonInclude.h")
 
 add_library(mitls STATIC ${SOURCES})
+
+target_compile_options(mitls PRIVATE ${QUIC_C_FLAGS})
 
 add_dependencies(mitls evercrypt)

--- a/msquic/msvc/quiccrypto/CMakeLists.txt
+++ b/msquic/msvc/quiccrypto/CMakeLists.txt
@@ -8,6 +8,5 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__STDC_FORMAT_MACROS /FI../include/CommonI
 add_library(quiccrypto STATIC quic_provider.c)
 
 target_compile_options(quiccrypto PRIVATE ${QUIC_C_FLAGS})
-target_compile_options(quiccrypto PRIVATE "-D__STDC_FORMAT_MACROS /FI../include/CommonInclude.h")
 
 add_dependencies(quiccrypto mitls)

--- a/msquic/msvc/quiccrypto/CMakeLists.txt
+++ b/msquic/msvc/quiccrypto/CMakeLists.txt
@@ -3,8 +3,9 @@
 
 include_directories(../include)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${QUIC_C_FLAGS} -D__STDC_FORMAT_MACROS /FI../include/CommonInclude.h")
-
 add_library(quiccrypto STATIC quic_provider.c)
+
+target_compile_options(quiccrypto PRIVATE ${QUIC_C_FLAGS})
+target_compile_options(quiccrypto PRIVATE "-D__STDC_FORMAT_MACROS /FI../include/CommonInclude.h")
 
 add_dependencies(quiccrypto mitls)

--- a/msquic/msvc/quiccrypto/CMakeLists.txt
+++ b/msquic/msvc/quiccrypto/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 include_directories(../include)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__STDC_FORMAT_MACROS /FI../include/CommonInclude.h")
+
 add_library(quiccrypto STATIC quic_provider.c)
 
 target_compile_options(quiccrypto PRIVATE ${QUIC_C_FLAGS})


### PR DESCRIPTION
We're using a list for the flags now to be compatible with target_compile_options, so the updates here had to be updated